### PR TITLE
Python project template Vagrantfile 1.0 / Initial project docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hdub-tech

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+# Description
+
+This PR:
+  1. Resolves GH-#
+  2. DOES_A_THING
+
+Before merging ensure:
+- [ ] validate job is passing
+- [ ] docs are updated, list:
+  -  [ ] README.md
+  -  [ ] DIR/README.md
+  -  [ ] project-specific/DIR/README.md
+
+---
+# Testing
+
+- [ ] `vagrant up` works without errors
+    <details>
+    
+    PICTURE
+    </details>
+
+- [ ] Specific things work when accessing the VM via `vagrant ssh`
+    - [ ] THING1
+    <details>
+    
+    PICTURE
+    </details>
+
+- [ ] `vagrant up --provision` works without errors (Idempotence) and doesn't cause env duplication
+    - [ ] THING1 
+    <details>
+    
+    PICTURE
+    </details>

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Personal environment related files
+.python-version
+.vagrant/
+.venv/
+
+# File generated in some templates
+vagrant-project-setup.sh

--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
+* [Description](#description)
+* [Requirements](#requirements)
+* [General Usage](#general-usage)
+* [Available files](#available-files)
+  * [Templates](#templates)
+  * [Project Specific](#project-specific)
+
 # Description
 
-This repo is just a collection of template and project specific Vagrantfiles that I use, and
-which I thought others might get use from. I'm not looking to start a huge project. I made
-some design choices that others might find questionable (for example, I deliberately skipped
+This repo is just a collection of template and project specific Vagrantfiles that I created
+as a way to learn Vagrant and more quickly stand-up development VMs for working on other
+projects. I'm not looking to start a huge project, but I thought others might get use from them.
+I made some design choices that others might find questionable (for example, I deliberately skipped
 taking advantage of the [File Provisioner](https://developer.hashicorp.com/vagrant/docs/provisioning/file) in favor of making completely self
-contained Vagrantfiles). So, while I'm definitely open to feedback and PRs (particularly for
-security issues), you will probably find it best to just fork/copy/mod what suits your fancy.
+contained Vagrantfiles). For the [project-specific](project-specific) ones, I don't do a fresh clone
+of the project but rather attach a pre-existing clone to /vagrant (That said the script used to
+set-up the project is copied to the VM so you can always clone fresh and re-run the script).
+So, while I'm definitely open to feedback and PRs (particularly for security issues), you will
+probably find it best to just fork/copy/mod what suits your fancy.
 
 Happy Virtualizing,
 H Dub
@@ -17,17 +28,29 @@ H Dub
   * [VirtualBox Guest Additions](https://www.virtualbox.org/manual/ch04.html#additions-linux) - for shared directories between host and guest.
 
 ---
+# General Usage
+
+Below is the general usage steps for these files. More specific instructions are included with each Vagrantfile.
+
+  1. Copy or symlink the desired Vagrantfile to the top level of the project you want to use it with.
+
+  2. **_IF_** it is **_NOT_** project-specific, update the variables in the block at the top of the Vagrantfile.
+
+  3. Run `vagrant up` in your project directory.
+
+---
 # Available files
 
 ## Templates
 
-All Templates are customizeable with a few variables at the top of their respective Vagrantfiles.
+All Templates are customizeable with a few variables at the top of their respective Vagrantfiles. Click on the
+Template name for a more detailed README.
 
-| Template | Description |
-| --- | --- |
-| [python](python) | Using [debian/bookworm64](https://app.vagrantup.com/debian/boxes/bookworm64), update the system, install specified apt_packages as well as optional Python module dependencies, install and setup pyenv for the vagrant user, install the specified version of Python and set it for the local project, create a venv for the project with the specified python_version if it doesn't exist and execute the project setup script specified by the user |
+| Template | Version | Description |
+| --- | --- | --- |
+| [python](python) | 1.0 | Using [debian/bookworm64](https://app.vagrantup.com/debian/boxes/bookworm64), update the system, install specified apt_packages as well as optional Python module dependencies, install and setup pyenv for the vagrant user, install the specified version of Python and set it for the local project, create a venv for the project with the specified python_version if it doesn't exist and execute the project setup script specified by the user. |
 
 ## Project Specific
 
-| Project | Vagrantfile | Template |
-| --- | --- | --- |
+| Project | Vagrantfile | Version | Template |
+| --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Description
+
+This repo is just a collection of template and project specific Vagrantfiles that I use, and
+which I thought others might get use from. I'm not looking to start a huge project. I made
+some design choices that others might find questionable (for example, I deliberately skipped
+taking advantage of the [File Provisioner](https://developer.hashicorp.com/vagrant/docs/provisioning/file) in favor of making completely self
+contained Vagrantfiles). So, while I'm definitely open to feedback and PRs (particularly for
+security issues), you will probably find it best to just fork/copy/mod what suits your fancy.
+
+Happy Virtualizing,
+H Dub
+
+---
+# Requirements
+* [Vagrant](https://developer.hashicorp.com/vagrant/docs/installation)
+* [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+  * [VirtualBox Guest Additions](https://www.virtualbox.org/manual/ch04.html#additions-linux) - for shared directories between host and guest.
+
+---
+# Available files
+
+## Templates
+
+All Templates are customizeable with a few variables at the top of their respective Vagrantfiles.
+
+| Template | Description |
+| --- | --- |
+| [python](python) | Using [debian/bookworm64](https://app.vagrantup.com/debian/boxes/bookworm64), update the system, install specified apt_packages as well as optional Python module dependencies, install and setup pyenv for the vagrant user, install the specified version of Python and set it for the local project, create a venv for the project with the specified python_version if it doesn't exist and execute the project setup script specified by the user |
+
+## Project Specific
+
+| Project | Vagrantfile | Template |
+| --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-* [Description](#description)
-* [Requirements](#requirements)
-* [General Usage](#general-usage)
-* [Available files](#available-files)
-  * [Templates](#templates)
-  * [Project Specific](#project-specific)
-
 # Description
 
 This repo is just a collection of template and project specific Vagrantfiles that I created
@@ -21,8 +14,18 @@ probably find it best to just fork/copy/mod what suits your fancy.
 Happy Virtualizing,
 H Dub
 
+* [Description](#description)
+* [Requirements](#requirements)
+* [General Usage](#general-usage)
+* [Available files](#available-files)
+  * [Templates](#templates)
+  * [Project Specific](#project-specific)
+
 ---
 # Requirements
+
+Install:
+
 * [Vagrant](https://developer.hashicorp.com/vagrant/docs/installation)
 * [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
   * [VirtualBox Guest Additions](https://www.virtualbox.org/manual/ch04.html#additions-linux) - for shared directories between host and guest.

--- a/python/README.md
+++ b/python/README.md
@@ -21,12 +21,12 @@ This [Vagrantfile](Vagrantfile) is based on the Official [debian/bookworm64](htt
 ---
 ## Variables
 
-This chart is the list of variables in the top of the Vagrantfile which you are encouraged to update based on your needs. To keep it [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself), rather than document default values here, please just see the corresponding [Vagrantfile](Vagrantfile).
+This chart is the list of variables in the top of the Vagrantfile which you are encouraged to update based on your needs. To keep it [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself), rather than document default values here, please just see the corresponding [Vagrantfile](Vagrantfile#L6-L41).
 
 | Variable | Type | Description |
 | --- | --- | --- |
 | `project_name` | String | Used as VM hostname and part of the VM name |
-| `python_version` | String | Any [pyenv supported version](https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build) of Python. Major only, or major.minor versions supported |
+| `python_version` | String | Any [pyenv supported version](https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build) of Python, including the unlisted `major` or `major.minor` versions, like `3` or `3.12` |
 | `python_version_abbrev` | String | Used as part of the `venv_dir` name, intended to replicate tox targets, like `py312` for Python 3.12. If you use something like `miniconda`, or any of the other named Pythons which pyenv supports, this name might be mangled into something like `pyminiconda3-312-24`. In this case, you might want to manually hardcode it to something like `py312` instead. |
 | `create_new_project_venv` | boolean | Whether or not to create a new `venv_dir` with prompt `venv_prompt` and activate it on login. If `false`, no venv actions will occur. If `true` and the `venv_dir` already exists, venv creation is skipped but it will be activated on login. |
 | `venv_dir` | String | If `create_new_project_venv` is true, this will be the path to the directory |
@@ -37,7 +37,7 @@ This chart is the list of variables in the top of the Vagrantfile which you are 
 ---
 Footnotes:
 
-  * <a id=1>1</a> - I deliberately went with strings as opposed to an array to make this easier for users to populate. This also includes a few things that **_I_** like on everything and which you might not care for.
+  * <a id=1>1</a> - I deliberately went with a string as opposed to an array to make this easier for users to populate. This also includes a few things that **_I_** like on everything and which you might not care for.
   * <a id=2>2</a> - Aka Interpolation and Esacaping is disabled, indentation is allowed but will be cleaned up on the final script. I didn't see a need for using Ruby variables in this and I usually want my scripts to be just like I wrote them, but I also like to indent for cleaner Vagrantfiles.
 
 ---

--- a/python/README.md
+++ b/python/README.md
@@ -27,9 +27,12 @@ This chart is the list of variables in the top of the Vagrantfile which you are 
 | --- | --- | --- |
 | `project_name` | String | Used as VM hostname and part of the VM name |
 | `python_version` | String | Any [pyenv supported version](https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build) of Python. Major only, or major.minor versions supported |
-| `create_new_project_venv` | boolean | Whether or not to create a new `.venv/vagrant-pyVERS` (`venv_dir`) with prompt `.venv $project_name-pyVERS` (`venv_prompt`) and activate it on login. If `false`, no venv actions will occur. If `true` and the `venv_dir` already exists, venv creation is skipped but it will be activated on login. |
+| `python_version_abbrev` | String | Used as part of the `venv_dir` name, intended to replicate tox targets, like `py312` for Python 3.12. If you use something like `miniconda`, or any of the other named Pythons which pyenv supports, this name might be mangled into something like `pyminiconda3-312-24`. In this case, you might want to manually hardcode it to something like `py312` instead. |
+| `create_new_project_venv` | boolean | Whether or not to create a new `venv_dir` with prompt `venv_prompt` and activate it on login. If `false`, no venv actions will occur. If `true` and the `venv_dir` already exists, venv creation is skipped but it will be activated on login. |
+| `venv_dir` | String | If `create_new_project_venv` is true, this will be the path to the directory |
+| `venv_prompt` | String | If `create_new_project_venv` is true, this will be the prompt in the venv. |
 | `apt_packages` | String (space separated)<sup>[1](#1)</sup> | The packaged which need to be installed in order to setup your project. You do NOT need to handle the Python dependencies here, just yours. |
-| `project_setup_script` | Heredoc (Squiggly Quoted)<sup>[2](#2)</sup> | This is where your project specific setup script goes. Examples inlcude things like `pip install -e .` and `pip install tox` |
+| `project_setup_script` | Heredoc (Squiggly Quoted)<sup>[2](#2)</sup> | This is where your project specific setup script goes. Examples include things like `pip install -e .` and `pip install tox` |
 
 ---
 Footnotes:

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,43 @@
+# Python Vagrantfile
+
+* [Description](#description)
+* [Variables](#variables)
+* [Changelog](#changelog)
+
+---
+## Description
+
+This [Vagrantfile](Vagrantfile) is based on the Official [debian/bookworm64](https://app.vagrantup.com/debian/boxes/bookworm64) box. It performs the actions listed below, in that order, as the user specified in parenthesis (where relevant). Refer to [Variables](#variables) for more info on the `$variables`.
+
+  1. Pull down the [debian/bookworm64](https://app.vagrantup.com/debian/boxes/bookworm64) Vagrant box.
+  2. Set hostname to `$project_name`.
+  3. Create VM with the name `$project_name-debian12-bookworm` in VirtualBox.
+  4. (root) Check for updated packages, upgrade system packages, and install the specified `$apt_packages` as well as the Python apt dependencies for required and optional modules.
+  5. (vagrant) If `~/.pyenv` does not exist, install pyenv via the hated pipe to bash method. Add the pyenv setup config to `~/.pyenvrc`, and source that file from `~/.bashrc`.
+  6. (vagrant) Install `$python_version` using [`pyenv`](https://github.com/pyenv/pyenv/blob/master/COMMANDS.md#pyenv-install) and set it as the local version for the project in `/vagrant`.
+  7. (vagrant) Create a [venv](https://docs.python.org/3/library/venv.html#creating-virtual-environments) in `$venv_dir` with `$venv_prompt` and set it to activate on login.
+  8. (vagrant) Run the user specified `$project_setup_script` and copy that script to `/vagrant/vagrant-project-setup.sh`.
+
+---
+## Variables
+
+This chart is the list of variables in the top of the Vagrantfile which you are encouraged to update based on your needs. To keep it [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself), rather than document default values here, please just see the corresponding [Vagrantfile](Vagrantfile).
+
+| Variable | Type | Description |
+| --- | --- | --- |
+| `project_name` | String | Used as VM hostname and part of the VM name |
+| `python_version` | String | Any [pyenv supported version](https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build) of Python. Major only, or major.minor versions supported |
+| `create_new_project_venv` | boolean | Whether or not to create a new `.venv/vagrant-pyVERS` (`venv_dir`) with prompt `.venv $project_name-pyVERS` (`venv_prompt`) and activate it on login. If `false`, no venv actions will occur. If `true` and the `venv_dir` already exists, venv creation is skipped but it will be activated on login. |
+| `apt_packages` | String (space separated)<sup>[1](#1)</sup> | The packaged which need to be installed in order to setup your project. You do NOT need to handle the Python dependencies here, just yours. |
+| `project_setup_script` | Heredoc (Squiggly Quoted)<sup>[2](#2)</sup> | This is where your project specific setup script goes. Examples inlcude things like `pip install -e .` and `pip install tox` |
+
+---
+Footnotes:
+
+  * <a id=1>1</a> - I deliberately went with strings as opposed to an array to make this easier for users to populate. This also includes a few things that **_I_** like on everything and which you might not care for.
+  * <a id=2>2</a> - Aka Interpolation and Esacaping is disabled, indentation is allowed but will be cleaned up on the final script. I didn't see a need for using Ruby variables in this and I usually want my scripts to be just like I wrote them, but I also like to indent for cleaner Vagrantfiles.
+
+---
+## Changelog
+
+* 1.0 - Initial Release

--- a/python/Vagrantfile
+++ b/python/Vagrantfile
@@ -1,25 +1,25 @@
-#          Copyright H Dub (hdub-tech) 2024
-# Distributed under the Boost Software License, Version 1.0.
-#    (See accompanying file LICENSE_1_0.txt or copy at
-#          https://www.boost.org/LICENSE_1_0.txt)
-
+#                     Copyright H Dub (hdub-tech) 2024
+#        Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE or copy at https://www.boost.org/LICENSE_1_0.txt
+#                     Python template - Version 1.0
+#
 # ####################################################################### #
-# vvvvvvvvvvvvvvvvvvvvvvv UPDATE THIS BLOCK BELOW vvvvvvvvvvvvvvvvvvvvvvv #
+#                         UPDATE THIS BLOCK BELOW                         #
 # ####################################################################### #
-# Get basename of current directory to be project name, or edit to hardcode
-# This will be the hostname and part of the VM name
+# Get basename of current directory to be project name, or edit to hardcode.
+# This will be the hostname and part of the VM name.
 $project_name = File.basename(__dir__)
 #$project_name = "hardcoded-name"
 
 # Set the desired Python version here
 $python_version = "3.12"
-
-# A new .venv/vagrant-py$python_version directory will be created at the
-# project level and used unless this is changed to false or the line
-# deleted/commented. The other venv variables should be acceptable at defaults
-# If the directory exists, it will not be touched.
-$create_new_project_venv = true
 $python_version_abbrev = "py#{$python_version.split('.').first(2).join('')}"  # ex) py312
+
+# A new .venv/vagrant-pyNNN directory will be created at the project level
+# and used unless this is changed to false or the line deleted/commented. The
+# other venv variables should be acceptable at defaults. If the directory exists,
+# it will not be touched.
+$create_new_project_venv = true
 $venv_dir = "/vagrant/.venv/vagrant-#{$python_version_abbrev}"
 $venv_prompt = ".venv #{$project_name}-#{$python_version_abbrev}"
 
@@ -34,7 +34,7 @@ $project_setup_script = <<~'PROJECT_SCRIPT'
   cd /vagrant  # Leave if you need to run commands from your project dir
 PROJECT_SCRIPT
 # ####################################################################### #
-# ^^^^^^^^^^^^^^^^^^^^^^^ UPDATE THIS BLOCK ABOVE ^^^^^^^^^^^^^^^^^^^^^^^ #
+#                         UPDATE THIS BLOCK ABOVE                         #
 # ####################################################################### #
 
 Vagrant.configure("2") do |config|

--- a/python/Vagrantfile
+++ b/python/Vagrantfile
@@ -13,7 +13,8 @@ $project_name = File.basename(__dir__)
 
 # Set the desired Python version here
 $python_version = "3.12"
-$python_version_abbrev = "py#{$python_version.split('.').first(2).join('')}"  # ex) py312
+# Ex) py312, like a tox target. If not using basic versions, you may want to edit this
+$python_version_abbrev = "py#{$python_version.split('.').first(2).join('')}"
 
 # A new .venv/vagrant-pyNNN directory will be created at the project level
 # and used unless this is changed to false or the line deleted/commented. The
@@ -24,7 +25,7 @@ $venv_dir = "/vagrant/.venv/vagrant-#{$python_version_abbrev}"
 $venv_prompt = ".venv #{$project_name}-#{$python_version_abbrev}"
 
 # Space separated list of system packages needed for this project. 
-$apt_packages = "git vim shellcheck"
+$apt_packages = "git vim"
 
 # Project dependencies setup script
 $project_setup_script = <<~'PROJECT_SCRIPT'
@@ -103,6 +104,7 @@ Vagrant.configure("2") do |config|
         if [ -e #{$venv_dir} ]; then
           echo "WARNING: #{$venv_dir} exists - Skipping venv creation" 1>&2
         else
+          echo "INFO: Creating venv at #{$venv_dir} with prompt (#{$venv_prompt})"
           python -m venv --upgrade-deps --prompt "#{$venv_prompt}" #{$venv_dir}
         fi
         if ! grep activate ~/.pyenvrc; then echo \"source #{$venv_dir}/bin/activate\" >> ~/.pyenvrc; fi

--- a/python/Vagrantfile
+++ b/python/Vagrantfile
@@ -1,0 +1,108 @@
+#          Copyright H Dub (hdub-tech) 2024
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          https://www.boost.org/LICENSE_1_0.txt)
+
+# ####################################################################### #
+# vvvvvvvvvvvvvvvvvvvvvvv UPDATE THIS BLOCK BELOW vvvvvvvvvvvvvvvvvvvvvvv #
+# ####################################################################### #
+# Get basename of current directory to be project name, or edit to hardcode
+# This will be the hostname and part of the VM name
+$project_name = File.basename(__dir__)
+#$project_name = "hardcoded-name"
+
+# Set the desired Python version here
+$python_version = "3.12"
+
+# A new .venv/vagrant-py$python_version directory will be created at the
+# project level and used unless this is changed to false or the line
+# deleted/commented. The other venv variables should be acceptable at defaults
+# If the directory exists, it will not be touched.
+$new_project_venv = true
+$python_version_abbrev = "py#{$python_version.split('.').first(2).join('')}"  # ex) py312
+$venv_dir = "/vagrant/.venv/vagrant-#{$python_version_abbrev}"
+$venv_prompt = ".venv #{$project_name}-#{$python_version_abbrev}"
+
+# Space separated list of system packages needed for this project. 
+$apt_packages = "git vim shellcheck"
+
+# Project dependencies setup script
+$project_setup_script = <<-'PROJECT_SCRIPT'
+  # NOTE: pip is already upgraded for you.
+  # Put your commands after THIS LINE to install project dependencies:
+
+  # Copy this script to the project directory in case it needs to be run again, excluding this comment/cmd
+  cat /tmp/vagrant-shell | head -n -2 | sed -e '1i#!/usr/bin/env bash' | tee /vagrant/vagrant-project-setup.sh  # delib no -a
+PROJECT_SCRIPT
+# ####################################################################### #
+# ^^^^^^^^^^^^^^^^^^^^^^^ UPDATE THIS BLOCK ABOVE ^^^^^^^^^^^^^^^^^^^^^^^ #
+# ####################################################################### #
+
+Vagrant.configure("2") do |config|
+
+  # Name the VM after the project and Vagrant instance type
+  config.vm.define "#{$project_name}-debian12-bookworm" do |dbw|
+    # Official Debian image
+    dbw.vm.box = "debian/bookworm64"
+    dbw.vm.hostname = $project_name
+
+    # VirtualBox configuration
+    dbw.vm.provider "virtualbox" do |v|
+      # UI name in VirtualBox
+      v.name = "#{$project_name}-debian12-bookworm"
+    end
+
+    # Install requested apt packages
+    dbw.vm.provision "Install specified apt packages [#{$apt_packages}]", type: "shell", inline: <<-APT_SCRIPT
+      apt-get update
+      apt-get --yes upgrade
+      apt-get --yes install #{$apt_packages}
+    APT_SCRIPT
+
+    # Install apt dependencies for all Python modules and install/setup pyenv
+    dbw.vm.provision "Install Python apt dependencies and install/setup pyenv", type: "shell", inline: <<-'PYENV_SETUP_SCRIPT'
+      apt-get install -y curl git gcc make zlib1g-dev libssl-dev libffi-dev libsqlite3-dev libbz2-dev libreadline-dev liblzma-dev
+      # Install pyenv if not already there
+      su -l vagrant -c "if [ ! -e ~/.pyenv ]; then curl https://pyenv.run | bash; fi"
+      # The BASH Heredocs must use tabs: https://www.shellcheck.net/wiki/SC1040
+      su -l vagrant <<-'BASH_COMMAND'
+		cat <<-'PYRC' | tee ~/.pyenvrc  # Deliberate no -a
+			export PYENV_ROOT="$HOME/.pyenv"
+			command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
+			eval "$(pyenv init -)"
+		PYRC
+		# Add "source .pyenvrc" to bashrc only if not already there
+		if ! grep pyenvrc ~/.bashrc; then echo "source ~/.pyenvrc" | tee -a ~/.bashrc; fi
+	BASH_COMMAND
+    PYENV_SETUP_SCRIPT
+
+    # Install specified Python version using pyenv and set at /vagrant/.python-version
+    dbw.vm.provision "Install Python #{$python_version} and set as local project version", type: "shell", inline: <<-PYENV_INSTALL_SCRIPT
+      su -l vagrant <<-BASH_COMMAND
+		source ~/.pyenvrc
+		pyenv install --skip-existing #{$python_version}
+		cd /vagrant
+		pyenv local #{$python_version}
+	BASH_COMMAND
+    PYENV_INSTALL_SCRIPT
+
+    # Create and setup venv, if specified
+    if $new_project_venv
+      dbw.vm.provision "Create venv and activate by default on login", type: "shell", inline: <<-VENV_SETUP_SCRIPT
+		su -l vagrant <<-BASH_COMMAND
+			source ~/.pyenvrc
+			cd /vagrant
+			if [ -e #{$venv_dir} ]; then
+				echo "#{$venv_dir} EXISTS - SKIPPING VENV CREATION"
+			else
+				python -m venv --upgrade-deps --prompt "#{$venv_prompt}" #{$venv_dir}
+			fi
+			if ! grep activate ~/.pyenvrc; then echo \"source #{$venv_dir}/bin/activate\" >> ~/.pyenvrc; fi
+		BASH_COMMAND
+	VENV_SETUP_SCRIPT
+    end
+ 
+    # Run project specific setup script
+    dbw.vm.provision "Run project setup script", type: "shell", inline: $project_setup_script
+  end
+end

--- a/python/Vagrantfile
+++ b/python/Vagrantfile
@@ -28,11 +28,10 @@ $apt_packages = "git vim shellcheck"
 
 # Project dependencies setup script
 $project_setup_script = <<~'PROJECT_SCRIPT'
-  # PUT YOUR COMMANDS HERE TO INSTALL PROJECT DEPENDENCIES
-  # NOTE: pip is already upgraded for you.
-
-  # Copy this script to the project directory in case it needs to be run again, excluding this comment/cmd
-  cat /tmp/vagrant-shell | head -n -2 | sed -e '1i#!/usr/bin/env bash' | tee /vagrant/vagrant-project-setup.sh  # delib no -a
+  # PUT YOUR COMMANDS HERE TO INSTALL PROJECT DEPENDENCIES AND SET YOUR NICITIES.
+  # NOTE: pip is already upgraded for you. Feel free to remove what you don't want/need
+  echo "cd /vagrant" >> ~/.bashrc  # Start in the project/mounted dir at login
+  cd /vagrant  # Leave if you need to run commands from your project dir
 PROJECT_SCRIPT
 # ####################################################################### #
 # ^^^^^^^^^^^^^^^^^^^^^^^ UPDATE THIS BLOCK ABOVE ^^^^^^^^^^^^^^^^^^^^^^^ #
@@ -63,8 +62,15 @@ Vagrant.configure("2") do |config|
 
     # Install apt dependencies for all Python modules and install/setup pyenv
     dbw.vm.provision "Install and setup pyenv", type: "shell", privileged: false, inline: <<~'PYENV_SETUP_SCRIPT'
+      set -e
       # Install pyenv if not already there
-      su -l vagrant -c "if [ ! -e ~/.pyenv ]; then curl https://pyenv.run | bash; fi"
+      if [ ! -e ~/.pyenv ]; then
+        # Split up due to noisy unnecessary stderr on both commands
+        curl --silent --output /tmp/pyenv.run https://pyenv.run
+        bash /tmp/pyenv.run 2>&1
+      else
+        echo "WARNING: ~/.pyenv exists - Skipping pyenv installation" 1>&2
+      fi
 	# The BASH Heredocs must use tabs: https://www.shellcheck.net/wiki/SC1040
         echo "INFO: Creating ~/.pyenrc to be sourced in ~/.bashrc with contents:"
 	cat <<-'PYRC' | tee ~/.pyenvrc  # Deliberate no -a
@@ -78,6 +84,7 @@ Vagrant.configure("2") do |config|
 
     # Install specified Python version using pyenv and set at /vagrant/.python-version
     dbw.vm.provision "Install Python #{$python_version} and set as local project version", type: "shell", privileged: false, inline: <<~PYENV_INSTALL_SCRIPT
+      set -e
       source ~/.pyenvrc
       pyenv install --skip-existing #{$python_version} 2>&1
       cd /vagrant
@@ -87,6 +94,7 @@ Vagrant.configure("2") do |config|
     # Create and setup venv, if specified
     if $create_new_project_venv
       dbw.vm.provision "Create venv and activate by default on login", type: "shell", privileged: false, inline: <<~VENV_SETUP_SCRIPT
+        set -e
         source ~/.pyenvrc
         cd /vagrant
         if [ -e #{$venv_dir} ]; then
@@ -100,7 +108,11 @@ Vagrant.configure("2") do |config|
  
     # Run project specific setup script
     dbw.vm.provision "Run project setup script", type: "shell", privileged: false, inline: <<~PROJECT_SETUP_SCRIPT
+      set -e
+      source ~/.pyenvrc
       #{$project_setup_script}
+      echo "INFO: Copying this script to the project directory in case it needs to be run again, excluding this comment/cmd"
+      cat /tmp/vagrant-shell | head -n -2 | sed -e '1i#!/usr/bin/env bash' | tee /vagrant/vagrant-project-setup.sh  # delib no -a
     PROJECT_SETUP_SCRIPT
   end
 end

--- a/python/Vagrantfile
+++ b/python/Vagrantfile
@@ -53,56 +53,54 @@ Vagrant.configure("2") do |config|
     end
 
     # Install requested apt packages
-    dbw.vm.provision "Install specified apt packages [#{$apt_packages}]", type: "shell", inline: <<~APT_SCRIPT
+    dbw.vm.provision "Install specified apt packages [#{$apt_packages}] and Python dependency packages", type: "shell", inline: <<~APT_SCRIPT
       apt-get update
       apt-get --yes upgrade
-      apt-get --yes install #{$apt_packages}
+      apt-get --yes install #{$apt_packages} \
+                            curl git gcc make zlib1g-dev libssl-dev libffi-dev libsqlite3-dev \
+                            libbz2-dev libreadline-dev liblzma-dev
     APT_SCRIPT
 
     # Install apt dependencies for all Python modules and install/setup pyenv
-    dbw.vm.provision "Install Python apt dependencies and install/setup pyenv", type: "shell", inline: <<~'PYENV_SETUP_SCRIPT'
-      apt-get install -y curl git gcc make zlib1g-dev libssl-dev libffi-dev libsqlite3-dev libbz2-dev libreadline-dev liblzma-dev
+    dbw.vm.provision "Install and setup pyenv", type: "shell", privileged: false, inline: <<~'PYENV_SETUP_SCRIPT'
       # Install pyenv if not already there
       su -l vagrant -c "if [ ! -e ~/.pyenv ]; then curl https://pyenv.run | bash; fi"
-      # The BASH Heredocs must use tabs: https://www.shellcheck.net/wiki/SC1040
-      su -l vagrant <<-'BASH_COMMAND'
-		cat <<-'PYRC' | tee ~/.pyenvrc  # Deliberate no -a
-			export PYENV_ROOT="$HOME/.pyenv"
-			command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
-			eval "$(pyenv init -)"
-		PYRC
-		# Add "source .pyenvrc" to bashrc only if not already there
-		if ! grep pyenvrc ~/.bashrc; then echo "source ~/.pyenvrc" | tee -a ~/.bashrc; fi
-	BASH_COMMAND
+	# The BASH Heredocs must use tabs: https://www.shellcheck.net/wiki/SC1040
+        echo "INFO: Creating ~/.pyenrc to be sourced in ~/.bashrc with contents:"
+	cat <<-'PYRC' | tee ~/.pyenvrc  # Deliberate no -a
+		export PYENV_ROOT="$HOME/.pyenv"
+		command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
+		eval "$(pyenv init -)"
+	PYRC
+      echo "INFO: Adding "source .pyenvrc" to bashrc, only if not already there"
+      if ! grep pyenvrc ~/.bashrc; then echo "source ~/.pyenvrc" | tee -a ~/.bashrc; fi
     PYENV_SETUP_SCRIPT
 
     # Install specified Python version using pyenv and set at /vagrant/.python-version
-    dbw.vm.provision "Install Python #{$python_version} and set as local project version", type: "shell", inline: <<~PYENV_INSTALL_SCRIPT
-      su -l vagrant <<-BASH_COMMAND
-		source ~/.pyenvrc
-		pyenv install --skip-existing #{$python_version}
-		cd /vagrant
-		pyenv local #{$python_version}
-	BASH_COMMAND
+    dbw.vm.provision "Install Python #{$python_version} and set as local project version", type: "shell", privileged: false, inline: <<~PYENV_INSTALL_SCRIPT
+      source ~/.pyenvrc
+      pyenv install --skip-existing #{$python_version} 2>&1
+      cd /vagrant
+      pyenv local #{$python_version}
     PYENV_INSTALL_SCRIPT
 
     # Create and setup venv, if specified
     if $create_new_project_venv
-      dbw.vm.provision "Create venv and activate by default on login", type: "shell", inline: <<~VENV_SETUP_SCRIPT
-        su -l vagrant <<-BASH_COMMAND
-		source ~/.pyenvrc
-		cd /vagrant
-		if [ -e #{$venv_dir} ]; then
-			echo "#{$venv_dir} EXISTS - SKIPPING VENV CREATION"
-		else
-			python -m venv --upgrade-deps --prompt "#{$venv_prompt}" #{$venv_dir}
-		fi
-		if ! grep activate ~/.pyenvrc; then echo \"source #{$venv_dir}/bin/activate\" >> ~/.pyenvrc; fi
-	BASH_COMMAND
+      dbw.vm.provision "Create venv and activate by default on login", type: "shell", privileged: false, inline: <<~VENV_SETUP_SCRIPT
+        source ~/.pyenvrc
+        cd /vagrant
+        if [ -e #{$venv_dir} ]; then
+          echo "WARNING: #{$venv_dir} exists - Skipping venv creation" 1>&2
+        else
+          python -m venv --upgrade-deps --prompt "#{$venv_prompt}" #{$venv_dir}
+        fi
+        if ! grep activate ~/.pyenvrc; then echo \"source #{$venv_dir}/bin/activate\" >> ~/.pyenvrc; fi
       VENV_SETUP_SCRIPT
     end
  
     # Run project specific setup script
-    dbw.vm.provision "Run project setup script", type: "shell", inline: $project_setup_script
+    dbw.vm.provision "Run project setup script", type: "shell", privileged: false, inline: <<~PROJECT_SETUP_SCRIPT
+      #{$project_setup_script}
+    PROJECT_SETUP_SCRIPT
   end
 end

--- a/python/Vagrantfile
+++ b/python/Vagrantfile
@@ -18,7 +18,7 @@ $python_version = "3.12"
 # project level and used unless this is changed to false or the line
 # deleted/commented. The other venv variables should be acceptable at defaults
 # If the directory exists, it will not be touched.
-$new_project_venv = true
+$create_new_project_venv = true
 $python_version_abbrev = "py#{$python_version.split('.').first(2).join('')}"  # ex) py312
 $venv_dir = "/vagrant/.venv/vagrant-#{$python_version_abbrev}"
 $venv_prompt = ".venv #{$project_name}-#{$python_version_abbrev}"
@@ -27,9 +27,9 @@ $venv_prompt = ".venv #{$project_name}-#{$python_version_abbrev}"
 $apt_packages = "git vim shellcheck"
 
 # Project dependencies setup script
-$project_setup_script = <<-'PROJECT_SCRIPT'
+$project_setup_script = <<~'PROJECT_SCRIPT'
+  # PUT YOUR COMMANDS HERE TO INSTALL PROJECT DEPENDENCIES
   # NOTE: pip is already upgraded for you.
-  # Put your commands after THIS LINE to install project dependencies:
 
   # Copy this script to the project directory in case it needs to be run again, excluding this comment/cmd
   cat /tmp/vagrant-shell | head -n -2 | sed -e '1i#!/usr/bin/env bash' | tee /vagrant/vagrant-project-setup.sh  # delib no -a
@@ -53,14 +53,14 @@ Vagrant.configure("2") do |config|
     end
 
     # Install requested apt packages
-    dbw.vm.provision "Install specified apt packages [#{$apt_packages}]", type: "shell", inline: <<-APT_SCRIPT
+    dbw.vm.provision "Install specified apt packages [#{$apt_packages}]", type: "shell", inline: <<~APT_SCRIPT
       apt-get update
       apt-get --yes upgrade
       apt-get --yes install #{$apt_packages}
     APT_SCRIPT
 
     # Install apt dependencies for all Python modules and install/setup pyenv
-    dbw.vm.provision "Install Python apt dependencies and install/setup pyenv", type: "shell", inline: <<-'PYENV_SETUP_SCRIPT'
+    dbw.vm.provision "Install Python apt dependencies and install/setup pyenv", type: "shell", inline: <<~'PYENV_SETUP_SCRIPT'
       apt-get install -y curl git gcc make zlib1g-dev libssl-dev libffi-dev libsqlite3-dev libbz2-dev libreadline-dev liblzma-dev
       # Install pyenv if not already there
       su -l vagrant -c "if [ ! -e ~/.pyenv ]; then curl https://pyenv.run | bash; fi"
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
     PYENV_SETUP_SCRIPT
 
     # Install specified Python version using pyenv and set at /vagrant/.python-version
-    dbw.vm.provision "Install Python #{$python_version} and set as local project version", type: "shell", inline: <<-PYENV_INSTALL_SCRIPT
+    dbw.vm.provision "Install Python #{$python_version} and set as local project version", type: "shell", inline: <<~PYENV_INSTALL_SCRIPT
       su -l vagrant <<-BASH_COMMAND
 		source ~/.pyenvrc
 		pyenv install --skip-existing #{$python_version}
@@ -87,19 +87,19 @@ Vagrant.configure("2") do |config|
     PYENV_INSTALL_SCRIPT
 
     # Create and setup venv, if specified
-    if $new_project_venv
-      dbw.vm.provision "Create venv and activate by default on login", type: "shell", inline: <<-VENV_SETUP_SCRIPT
-		su -l vagrant <<-BASH_COMMAND
-			source ~/.pyenvrc
-			cd /vagrant
-			if [ -e #{$venv_dir} ]; then
-				echo "#{$venv_dir} EXISTS - SKIPPING VENV CREATION"
-			else
-				python -m venv --upgrade-deps --prompt "#{$venv_prompt}" #{$venv_dir}
-			fi
-			if ! grep activate ~/.pyenvrc; then echo \"source #{$venv_dir}/bin/activate\" >> ~/.pyenvrc; fi
-		BASH_COMMAND
-	VENV_SETUP_SCRIPT
+    if $create_new_project_venv
+      dbw.vm.provision "Create venv and activate by default on login", type: "shell", inline: <<~VENV_SETUP_SCRIPT
+        su -l vagrant <<-BASH_COMMAND
+		source ~/.pyenvrc
+		cd /vagrant
+		if [ -e #{$venv_dir} ]; then
+			echo "#{$venv_dir} EXISTS - SKIPPING VENV CREATION"
+		else
+			python -m venv --upgrade-deps --prompt "#{$venv_prompt}" #{$venv_dir}
+		fi
+		if ! grep activate ~/.pyenvrc; then echo \"source #{$venv_dir}/bin/activate\" >> ~/.pyenvrc; fi
+	BASH_COMMAND
+      VENV_SETUP_SCRIPT
     end
  
     # Run project specific setup script

--- a/python/Vagrantfile
+++ b/python/Vagrantfile
@@ -29,9 +29,12 @@ $apt_packages = "git vim shellcheck"
 # Project dependencies setup script
 $project_setup_script = <<~'PROJECT_SCRIPT'
   # PUT YOUR COMMANDS HERE TO INSTALL PROJECT DEPENDENCIES AND SET YOUR NICITIES.
-  # NOTE: pip is already upgraded for you. Feel free to remove what you don't want/need
-  echo "cd /vagrant" >> ~/.bashrc  # Start in the project/mounted dir at login
-  cd /vagrant  # Leave if you need to run commands from your project dir
+  # NOTE: pip is already upgraded for you. Feel free to remove what you don't want/need.
+  set -e                           # Exit on error
+  # Always start in the project/mounted dir at login
+  if ! grep "cd /vagrant" ~/.bashrc; then echo "cd /vagrant" >> ~/.bashrc; fi
+  cd /vagrant                      # Change to the project/mounted dir
+  source ~/.pyenvrc                # Use the just installed python and activate $venv_dir
 PROJECT_SCRIPT
 # ####################################################################### #
 #                         UPDATE THIS BLOCK ABOVE                         #
@@ -60,7 +63,7 @@ Vagrant.configure("2") do |config|
                             libbz2-dev libreadline-dev liblzma-dev
     APT_SCRIPT
 
-    # Install apt dependencies for all Python modules and install/setup pyenv
+    # Install and setup pyenv
     dbw.vm.provision "Install and setup pyenv", type: "shell", privileged: false, inline: <<~'PYENV_SETUP_SCRIPT'
       set -e
       # Install pyenv if not already there
@@ -108,8 +111,6 @@ Vagrant.configure("2") do |config|
  
     # Run project specific setup script
     dbw.vm.provision "Run project setup script", type: "shell", privileged: false, inline: <<~PROJECT_SETUP_SCRIPT
-      set -e
-      source ~/.pyenvrc
       #{$project_setup_script}
       echo "INFO: Copying this script to the project directory in case it needs to be run again, excluding this comment/cmd"
       cat /tmp/vagrant-shell | head -n -2 | sed -e '1i#!/usr/bin/env bash' | tee /vagrant/vagrant-project-setup.sh  # delib no -a


### PR DESCRIPTION
# Description

This PR:
  1. Adds initial .git files and README.
  2. Adds version 1.0 of the Python project template Vagrantfile

Before merging ensure:
- [x] validate job is passing... not implemented yet. See Testing below
- [x] docs are updated, list:
  -  [x] README.md
  -  [x] python/README.md

---
# Testing
## Python
- [x] `vagrant up` works without errors
    <details>
    
    ![image](https://github.com/hdub-tech/vagrantfiles/assets/14808878/a7324113-2cf7-4136-8058-a6ceb7b7e156)
    ![image](https://github.com/hdub-tech/vagrantfiles/assets/14808878/82be7135-77c4-4442-9b5d-05f61d11740d)
    ![image](https://github.com/hdub-tech/vagrantfiles/assets/14808878/e4b6303d-a6f8-46ab-90a6-a0af4c82249c)

    </details>

- [x] SPECIFIC_THINGS work when accessing the VM via `vagrant ssh`
    - [x] venv automatically activated with ".venv dirname-pythonAbbrevVersion"
    - [x] hosntame is dir name (python)
    - [x] VM name is dirname-imagename
    - [x] `pyenv versions` has specified python (3.12)
    - [x] Project directory has vagrant-project-setup-script.sh with the extraneous lines omitted 
    <details>
    
    ![image](https://github.com/hdub-tech/vagrantfiles/assets/14808878/11c05d5f-6e2c-413f-b3a4-ce88c1cdce93)
    </details>

- [x] `vagrant up --provision` works without errors and no doubling up on re-run (Idempotence)
    - [x] tail ~/.bashrc
    - [x] cat ~/.pyenvrc
    - [x] cat vagrant-project-setup.sh
    <details>
    
    ![image](https://github.com/hdub-tech/vagrantfiles/assets/14808878/0b5d50a1-4bdf-42ea-ad7b-0152055be76a)
    ![image](https://github.com/hdub-tech/vagrantfiles/assets/14808878/47fd7b35-41b7-47f7-8bc0-7aa120077878)

    </details>

- [x] `vagrant up` with modifications for no venv created and using a hardcoded name and a diff version of python.
    <details>
    
    ![image](https://github.com/hdub-tech/vagrantfiles/assets/14808878/689cc7e4-e76b-4421-a089-1067e4647fb0)

    </details>