### PR TITLE
Kali VM 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 .venv/
 
 # File generated in some templates
-vagrant-project-setup.sh
+vagrant-*-setup.sh

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Template name for a more detailed README.
 | Template | Version | Description |
 | --- | --- | --- |
 | [python](python) | 1.0 | Using [debian/bookworm64](https://app.vagrantup.com/debian/boxes/bookworm64), update the system, install specified apt_packages as well as optional Python module dependencies, install and setup pyenv for the vagrant user, install the specified version of Python and set it for the local project, create a venv for the project with the specified python_version if it doesn't exist and execute the project setup script specified by the user. |
+| [kali](kali) | 1.0 | Using [kalilinux/rolling](https://app.vagrantup.com/kalilinux/boxes/rolling), install pyenv, specified version of Python, specified pip and apt packages, checkout the specified git repos, pipx install the specified project, and set some VM properties. Provisioning defaults to unprivileged, but this can be overriden. |
 
 ## Project Specific
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,10 @@
 # Description
 
-This repo is just a collection of template and project specific Vagrantfiles that I created
-as a way to learn Vagrant and more quickly stand-up development VMs for working on other
-projects. I'm not looking to start a huge project, but I thought others might get use from them.
-I made some design choices that others might find questionable (for example, I deliberately skipped
-taking advantage of the [File Provisioner](https://developer.hashicorp.com/vagrant/docs/provisioning/file) in favor of making completely self
-contained Vagrantfiles). For the [project-specific](project-specific) ones, I don't do a fresh clone
-of the project but rather attach a pre-existing clone to /vagrant (That said the script used to
-set-up the project is copied to the VM so you can always clone fresh and re-run the script).
-So, while I'm definitely open to feedback and PRs (particularly for security issues), you will
-probably find it best to just fork/copy/mod what suits your fancy.
+This repo is just a collection of template and project specific Vagrantfiles that I created as a way to learn Vagrant and more quickly stand-up development VMs for working on other projects. I'm not looking to start a huge project, but I thought others might get use from them.
+
+I made some design choices that others might find questionable (for example, I deliberately skipped taking advantage of the [File Provisioner](https://developer.hashicorp.com/vagrant/docs/provisioning/file) in favor of making completely self contained Vagrantfiles). For the [project-specific](project-specific) ones, I don't do a fresh clone of the project but rather attach a pre-existing clone to /vagrant (That said the script used to set-up the project is copied to the VM so you can always clone fresh and re-run the script). And possibly most obviously, I'm doing a ton in shell provisioners which would be better suited for a configuration management tool like Ansible, which I know pretty intimately even. I'm just seeing how far I can push the monolithic Vagrantfile without additional tools required.
+
+So, while I'm definitely open to feedback and PRs (particularly for security issues), you will probably find it best to just fork/copy/mod what suits your fancy.
 
 Happy Virtualizing,
 H Dub
@@ -55,6 +50,8 @@ Template name for a more detailed README.
 | [kali](kali) | 1.0 | Using [kalilinux/rolling](https://app.vagrantup.com/kalilinux/boxes/rolling), install pyenv, specified version of Python, specified pip and apt packages, checkout the specified git repos, pipx install the specified project, and set some VM properties. Provisioning defaults to unprivileged, but this can be overriden. |
 
 ## Project Specific
+
+Project specific VMs are meant to correspond to Github projects which don't already have a Vagrantfile.
 
 | Project | Vagrantfile | Version | Template |
 | --- | --- | --- | --- |

--- a/kali/README.md
+++ b/kali/README.md
@@ -1,0 +1,54 @@
+# Kali Vagrantfile
+
+* [Description](#description)
+* [Variables](#variables)
+* [Changelog](#changelog)
+
+---
+## Description
+
+This [Vagrantfile](Vagrantfile) is based on the Official [kalilinux/rolling](https://app.vagrantup.com/kalilinux/boxes/rolling) box. It performs the actions listed below, in that order, as the user specified (The "root or vagrant" steps depend on the `$run_as_root` variable). Refer to [Variables](#variables) for more info on the `$variables`.
+
+  1. Create VM with the name `$vm_name` in VirtualBox.
+  2. Pull down the [kalilinux/rolling](https://app.vagrantup.com/kalilinux/boxes/rolling) Vagrant box.
+  3. Set hostname to `$hostname`.
+  4. Sync `$local_shared_dir` on the host to `/vagrant` in the guest Kali VM.
+  5. Disable the ["VirtualBox Remote Desktop" server](https://www.virtualbox.org/manual/ch07.html#vrde) which Kali(???) is enabling???
+  6. (root) Check for updated packages, upgrade system packages, and install the specified `$apt_packages` as well as the Python apt dependencies for required and optional modules.
+  7. (root or vagrant) If `~/.pyenv` does not exist, install [pyenv](https://github.com/pyenv/pyenv) via the hated pipe to bash method. Add the pyenv setup config to `/etc/profile.d/pyenvrc`, and source that file from `~/.profile` and the `$preferred_shell` home rc file.
+  8. (root or vagrant) Install `$python_version` using [`pyenv`](https://github.com/pyenv/pyenv/blob/master/COMMANDS.md#pyenv-install) and set it as the `pyenv global` version. Install the specified `$pip_packages` into that `pyenv`, and upgrade its pip.
+  9. (root or vagrant) If a list of `$git_repos` is specified, clone them to `$git_repos_dir`. See Variable footnote [#3](#3) for some implementation details.
+  10. (root or vagrant) If a list of `$pipx_projects` is specified, run `pipx install` to install them into the `pyenv global` `$python_version` environment and then run `pipx ensurepath` to make sure they are accessible upon login.
+  11. (root or vagrant) Run the user specified `$custom_setup_script` and copy that script to `/vagrant/vagrant-custom-setup.sh`.
+
+---
+## Variables
+
+This chart is the list of variables in the top of the Vagrantfile which you are encouraged to update based on your needs. To keep it [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself), rather than document default values here, please just see the corresponding [Vagrantfile](Vagrantfile#L6-L70).
+
+| Variable | Type | Description |
+| --- | --- | --- |
+| `vm_name` | String | Used as VM name |
+| `hostname` | String | Used as VM hostname |
+| `preferred_shell` | String | Name, not path<sup>[1](#1)</sup>. Used to update `$HOME/.*rc` files appropriately for pyenv and pipx, and optionally with `chsh` |
+| `local_shared_dir` | String | The directory on the system which will be mounted to `/vagrant` in the VM |
+| `run_as_root` | boolean | Whether or not to run the shell provisioners as root<sup>[2](#2)</sup>. If false, uses the vagrant user |
+| `python_version` | String | Any [pyenv supported version](https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build) of Python, including the unlisted `major` or `major.minor` versions, like `3` or `3.12`. This will be set as the `pyenv global` default |
+| `apt_packages` | Array[String] | The packages you need/want installed in the VM. You do NOT need to handle the Python dependencies here, just yours. |
+| `git_repos_dir` | String | The full path to the directory you want to clone github repos in to<sup>[3](#3)</sup> |
+| `pip_packages` | Array[String] | The `pip` packages to install into the `pyenv global` default |
+| `pipx_packages` | Array[String] | A list of directories (full path) which contain Python projects which `pipx install` will be executed to install them into the `pyenv global` default |
+| `custom_setup_script` | Heredoc (Squiggly Unquoted)<sup>[4](#4)</sup> | This is where your custom setup script goes. Examples include things like `chsh -s ` and adding a `cd /vagrant` to the `$preferred_shell` rc file |
+
+---
+Footnotes:
+
+  * <a id=1>1</a> - Example: `bash`. Only tested with `bash` and `zsh`.
+  * <a id=2>2</a> - The apt install provisioner will be run as root regardless of this setting.
+  * <a id=3>3</a> - If `$run_as_root` is false and the non-root user doesn't have write perms in the specified `$git_repos_dir`, `sudo` will be used with the `git clone` operation seeing as the Vagrantfile cam run sudo anyways. As an example, `/opt` is a traditional directory to throw optional additional software, and the default for this Vagrantfile, but the `vagrant` user cannot write there without `sudo`. The cloned directories (NOT `$git_repos_dir`), will have their ownership changed to the non-root user.
+  * <a id=4>4</a> Aka Interpolation and Esacaping is enabled, indentation is allowed but will be cleaned up on the final script.
+
+---
+## Changelog
+
+* 1.0 - Initial Release

--- a/kali/README.md
+++ b/kali/README.md
@@ -15,11 +15,12 @@ This [Vagrantfile](Vagrantfile) is based on the Official [kalilinux/rolling](htt
   4. Sync `$local_shared_dir` on the host to `/vagrant` in the guest Kali VM.
   5. Disable the ["VirtualBox Remote Desktop" server](https://www.virtualbox.org/manual/ch07.html#vrde) which Kali(???) is enabling???
   6. (root) Check for updated packages, upgrade system packages, and install the specified `$apt_packages` as well as the Python apt dependencies for required and optional modules.
-  7. (root or vagrant) If `~/.pyenv` does not exist, install [pyenv](https://github.com/pyenv/pyenv) via the hated pipe to bash method. Add the pyenv setup config to `/etc/profile.d/pyenvrc`, and source that file from `~/.profile` and the `$preferred_shell` home rc file.
-  8. (root or vagrant) Install `$python_version` using [`pyenv`](https://github.com/pyenv/pyenv/blob/master/COMMANDS.md#pyenv-install) and set it as the `pyenv global` version. Install the specified `$pip_packages` into that `pyenv`, and upgrade its pip.
-  9. (root or vagrant) If a list of `$git_repos` is specified, clone them to `$git_repos_dir`. See Variable footnote [#3](#3) for some implementation details.
-  10. (root or vagrant) If a list of `$pipx_projects` is specified, run `pipx install` to install them into the `pyenv global` `$python_version` environment and then run `pipx ensurepath` to make sure they are accessible upon login.
-  11. (root or vagrant) Run the user specified `$custom_setup_script` and copy that script to `/vagrant/vagrant-custom-setup.sh`.
+  7. (root) Change the login shell to `$preferred_shell` for (root or vagrant) depending on `$run_as_root`.
+  8. (root or vagrant) If `~/.pyenv` does not exist, install [pyenv](https://github.com/pyenv/pyenv) via the hated pipe to bash method. Add the pyenv setup config to `/etc/profile.d/pyenvrc`, and source that file from `~/.profile` and the `$preferred_shell` home rc file.
+  9. (root or vagrant) Install `$python_version` using [`pyenv`](https://github.com/pyenv/pyenv/blob/master/COMMANDS.md#pyenv-install) and set it as the `pyenv global` version. Install the specified `$pip_packages` into that `pyenv`, and upgrade its pip and pipx
+  10. (root or vagrant) If a list of `$git_repos` is specified, clone them to `$git_repos_dir`. See Variable footnote [#3](#3) for some implementation details.
+  11. (root or vagrant) If a list of `$pipx_projects` is specified, run `pipx install` to install them into the `pyenv global` `$python_version` environment and then run `pipx ensurepath` to make sure they are accessible upon login.
+  12. (root or vagrant) Run the user specified `$custom_setup_script` and copy that script to `/vagrant/vagrant-custom-setup.sh`.
 
 ---
 ## Variables
@@ -30,22 +31,23 @@ This chart is the list of variables in the top of the Vagrantfile which you are 
 | --- | --- | --- |
 | `vm_name` | String | Used as VM name |
 | `hostname` | String | Used as VM hostname |
-| `preferred_shell` | String | Name, not path<sup>[1](#1)</sup>. Used to update `$HOME/.*rc` files appropriately for pyenv and pipx, and optionally with `chsh` |
+| `preferred_shell` | String | Name, not path<sup>[1](#1)</sup>. Used to change the login shell for the (root or vagrant) user (based on `$run_as_root`, in order to update `$HOME/.*rc` files appropriately for pyenv and pipx |
 | `local_shared_dir` | String | The directory on the system which will be mounted to `/vagrant` in the VM |
 | `run_as_root` | boolean | Whether or not to run the shell provisioners as root<sup>[2](#2)</sup>. If false, uses the vagrant user |
 | `python_version` | String | Any [pyenv supported version](https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build) of Python, including the unlisted `major` or `major.minor` versions, like `3` or `3.12`. This will be set as the `pyenv global` default |
 | `apt_packages` | Array[String] | The packages you need/want installed in the VM. You do NOT need to handle the Python dependencies here, just yours. |
 | `git_repos_dir` | String | The full path to the directory you want to clone github repos in to<sup>[3](#3)</sup> |
-| `pip_packages` | Array[String] | The `pip` packages to install into the `pyenv global` default |
-| `pipx_packages` | Array[String] | A list of directories (full path) which contain Python projects which `pipx install` will be executed to install them into the `pyenv global` default |
-| `custom_setup_script` | Heredoc (Squiggly Unquoted)<sup>[4](#4)</sup> | This is where your custom setup script goes. Examples include things like `chsh -s ` and adding a `cd /vagrant` to the `$preferred_shell` rc file |
+| `git_repos` | Array[String] | The https URLs to the git repos the user wants to close WITHOUT THE `.git` at the end (the basename will be used to determine if it is already cloned) |
+| `pip_packages` | Array[String] | The `pip` packages to install into the `pyenv global` default (`pipx` will be installed here already) |
+| `pipx_packages` | Array[String] | A list of directories (full path) which contain Python projects on which `pipx install` will be executed to install them into the `pyenv global` default |
+| `custom_setup_script` | Heredoc (Squiggly Unquoted)<sup>[4](#4)</sup> | This is where your custom setup script goes. Example: adding a `cd /vagrant` to the `$preferred_shell` rc file to always start in the shared directory |
 
 ---
 Footnotes:
 
   * <a id=1>1</a> - Example: `bash`. Only tested with `bash` and `zsh`.
-  * <a id=2>2</a> - The apt install provisioner will be run as root regardless of this setting.
-  * <a id=3>3</a> - If `$run_as_root` is false and the non-root user doesn't have write perms in the specified `$git_repos_dir`, `sudo` will be used with the `git clone` operation seeing as the Vagrantfile cam run sudo anyways. As an example, `/opt` is a traditional directory to throw optional additional software, and the default for this Vagrantfile, but the `vagrant` user cannot write there without `sudo`. The cloned directories (NOT `$git_repos_dir`), will have their ownership changed to the non-root user.
+  * <a id=2>2</a> - The apt install and chsh provisioners will be run as root regardless of this setting.
+  * <a id=3>3</a> - If `$run_as_root` is false and the non-root user doesn't have write perms in the specified `$git_repos_dir`, `sudo` will be used with the `git clone` operation seeing as the Vagrantfile can run sudo anyways. As an example, `/opt` is a traditional directory to throw optional additional software, and the default for this Vagrantfile, but the `vagrant` user cannot write there without `sudo`. The cloned directories (NOT `$git_repos_dir` itself), will have their ownership changed to the non-root user in this situation.
   * <a id=4>4</a> Aka Interpolation and Esacaping is enabled, indentation is allowed but will be cleaned up on the final script.
 
 ---

--- a/kali/README.md
+++ b/kali/README.md
@@ -22,10 +22,9 @@ This [Vagrantfile](Vagrantfile) is based on the Official [kalilinux/rolling](htt
   11. (root or vagrant) If a list of `$pipx_projects` is specified, run `pipx install` to install them into the `pyenv global` `$python_version` environment and then run `pipx ensurepath` to make sure they are accessible upon login.
   12. (root or vagrant) Run the user specified `$custom_setup_script` and copy that script to `/vagrant/vagrant-custom-setup.sh`.
 
----
 ## Variables
 
-This chart is the list of variables in the top of the Vagrantfile which you are encouraged to update based on your needs. To keep it [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself), rather than document default values here, please just see the corresponding [Vagrantfile](Vagrantfile#L6-L70).
+This chart is the list of variables in the top of the Vagrantfile which you are encouraged to update based on your needs. To keep it [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself), rather than document default values here, please just see the corresponding [Vagrantfile](Vagrantfile#L6-L58).
 
 | Variable | Type | Description |
 | --- | --- | --- |
@@ -35,9 +34,9 @@ This chart is the list of variables in the top of the Vagrantfile which you are 
 | `local_shared_dir` | String | The directory on the system which will be mounted to `/vagrant` in the VM |
 | `run_as_root` | boolean | Whether or not to run the shell provisioners as root<sup>[2](#2)</sup>. If false, uses the vagrant user |
 | `python_version` | String | Any [pyenv supported version](https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build) of Python, including the unlisted `major` or `major.minor` versions, like `3` or `3.12`. This will be set as the `pyenv global` default |
-| `apt_packages` | Array[String] | The packages you need/want installed in the VM. You do NOT need to handle the Python dependencies here, just yours. |
+| `apt_packages` | Array[String] | The packages you need/want installed in the VM. You do NOT need to handle the Python dependencies here, just yours |
 | `git_repos_dir` | String | The full path to the directory you want to clone github repos in to<sup>[3](#3)</sup> |
-| `git_repos` | Array[String] | The https URLs to the git repos the user wants to close WITHOUT THE `.git` at the end (the basename will be used to determine if it is already cloned) |
+| `git_repos` | Array[String] | The https URLs to the git repos the user wants to clone WITHOUT THE `.git` at the end (the basename will be used to determine if it is already cloned) |
 | `pip_packages` | Array[String] | The `pip` packages to install into the `pyenv global` default (`pipx` will be installed here already) |
 | `pipx_packages` | Array[String] | A list of directories (full path) which contain Python projects on which `pipx install` will be executed to install them into the `pyenv global` default |
 | `custom_setup_script` | Heredoc (Squiggly Unquoted)<sup>[4](#4)</sup> | This is where your custom setup script goes. Example: adding a `cd /vagrant` to the `$preferred_shell` rc file to always start in the shared directory |

--- a/kali/Vagrantfile
+++ b/kali/Vagrantfile
@@ -50,9 +50,8 @@ $custom_setup_script = <<~CUSTOM_SETUP_SCRIPT
   # NOTE: pip is already upgraded for you. Feel free to remove what you don't want/need.
   set -e                           # Exit on error
   echo -n "INFO: Running as " && whoami
-  sudo chsh -s /usr/bin/#{$preferred_shell} #{ $run_as_root ? 'root' : 'vagrant' }
   # Always start in the project/mounted dir at login
-  if ! grep "cd /vagrant" ~/.#{$preferred_shell}rc; then echo "cd /vagrant" >> ~/.#{$preferred_shell}rc; fi
+  if ! grep -q "cd /vagrant" ~/.#{$preferred_shell}rc; then echo "cd /vagrant" | tee -a ~/.#{$preferred_shell}rc; fi
   #cd /vagrant                      # Change to the project/mounted dir
 CUSTOM_SETUP_SCRIPT
 # ####################################################################### #
@@ -85,6 +84,10 @@ Vagrant.configure("2") do |config|
                             libbz2-dev libreadline-dev liblzma-dev
     APT_SCRIPT
 
+    # Preferred shell - need to update before modifying settings in rc files
+    primary_user = $run_as_root ? 'root' : 'vagrant'
+    kali.vm.provision "Set #{primary_user}'s preferred shell to #{$preferred_shell}", type: "shell", privileged: true, inline: "chsh -s /usr/bin/#{$preferred_shell} #{primary_user}"
+
     # Install and setup pyenv
     pyenvrc_file = "/etc/profile.d/pyenvrc"
     kali.vm.provision "Install and setup pyenv", type: "shell", privileged: $run_as_root, inline: <<~PYENV_SETUP_SCRIPT
@@ -105,8 +108,8 @@ Vagrant.configure("2") do |config|
 		eval "$(pyenv init -)"
 	PYRC
       echo "INFO: Adding ". #{pyenvrc_file}" to ~/.#{$preferred_shell}rc and ~/.profile, only if not already there"
-      if ! grep #{pyenvrc_file} ~/.#{$preferred_shell}rc; then echo ". #{pyenvrc_file}" | tee -a ~/.#{$preferred_shell}rc; fi
-      if ! grep #{pyenvrc_file} ~/.profile; then echo ". #{pyenvrc_file}" | tee -a ~/.profile; fi
+      if ! grep -q #{pyenvrc_file} ~/.#{$preferred_shell}rc; then echo ". #{pyenvrc_file}" | tee -a ~/.#{$preferred_shell}rc; fi
+      if ! grep -q #{pyenvrc_file} ~/.profile; then echo ". #{pyenvrc_file}" | tee -a ~/.profile; fi
     PYENV_SETUP_SCRIPT
 
     # Install specified Python version using pyenv and set as global default
@@ -129,15 +132,15 @@ Vagrant.configure("2") do |config|
             clone_needs_sudo="sudo"
           fi
         else
-          echo mkdir #{$git_repos_dir}
+          mkdir #{$git_repos_dir}
         fi
         cd #{$git_repos_dir}
         for url in `echo #{$git_repos.join(' ')}`; do
-          project_dir=${url##http*/} 
+          project_dir=${url##http*/}
           echo "INFO: Cloning $url to #{$git_repos_dir}/$project_dir..."
           if [ ! -d $project_dir ]; then
             $clone_needs_sudo git clone $url
-            if (("${#clone_needs_sudo[@]}" > 0)); then sudo chown -R vagrant $project_dir; fi
+            if (("${#clone_needs_sudo}" > 0)); then sudo chown -R vagrant $project_dir; fi
           else
             echo "already exists - skipping" 1>&2
           fi
@@ -155,7 +158,9 @@ Vagrant.configure("2") do |config|
           pipx install #{path}
         PIPX_INSTALL_SCRIPT
       end
-      kali.vm.provision "Running pipx ensurepath", type: "shell", privileged: $run_as_root, inline: "pipx ensurepath"
+
+      # pipx ensurepath + vagrant seems to need special su work to get it to update a non-default shell for root.
+      kali.vm.provision "Running pipx ensurepath for #{primary_user}", type: "shell", privileged: true, inline: "su -l #{primary_user} -c \"pipx ensurepath\""
     end
 
     # Run custom specific setup script

--- a/kali/Vagrantfile
+++ b/kali/Vagrantfile
@@ -1,0 +1,169 @@
+#                     Copyright H Dub (hdub-tech) 2024
+#        Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE or copy at https://www.boost.org/LICENSE_1_0.txt
+#                     Kali template - Version 1.0
+#
+# ####################################################################### #
+#                         UPDATE THIS BLOCK BELOW                         #
+# ####################################################################### #
+$vm_name = "vagrant-kalilinux-rolling"
+$hostname = "kali"
+
+# Only tested with bash/zsh
+$preferred_shell = "bash"
+
+# The folder on your system to share at /vagrant in the VM
+$local_shared_dir = "."
+
+# If false, the shell provisioners will run as the vagrant user
+$run_as_root = false
+
+# The version of Python to install with pyenv and set as the pyenv global default
+$python_version = "3.12"
+
+# These will be installed as root regardless of $run_as_root
+$apt_packages = [
+  "git",
+  "tree",
+  "vim"
+]
+
+# The directory to run git clone from
+$git_repos_dir = "/opt"
+$git_repos = [
+  "https://github.com/fortra/impacket",
+  "https://github.com/ly4k/Certipy"
+]
+
+# Packages to install with pip into pyenv $python_version
+$pip_packages = [
+  "pipx"
+]
+
+# Full path to projects to install with pipx using pyenv $python_version
+$pipx_projects = [
+  "#{$git_repos_dir}/impacket"
+]
+
+# Custom setup and nicities script
+$custom_setup_script = <<~CUSTOM_SETUP_SCRIPT
+  # PUT YOUR COMMANDS HERE TO INSTALL PROJECT DEPENDENCIES AND SET YOUR NICITIES.
+  # NOTE: pip is already upgraded for you. Feel free to remove what you don't want/need.
+  set -e                           # Exit on error
+  echo -n "INFO: Running as " && whoami
+  sudo chsh -s /usr/bin/#{$preferred_shell} #{ $run_as_root ? 'root' : 'vagrant' }
+  # Always start in the project/mounted dir at login
+  if ! grep "cd /vagrant" ~/.#{$preferred_shell}rc; then echo "cd /vagrant" >> ~/.#{$preferred_shell}rc; fi
+  #cd /vagrant                      # Change to the project/mounted dir
+CUSTOM_SETUP_SCRIPT
+# ####################################################################### #
+#                         UPDATE THIS BLOCK ABOVE                         #
+# ####################################################################### #
+
+Vagrant.configure("2") do |config|
+
+  # Name the VM specifically
+  config.vm.define $vm_name do |kali|
+    # Official Kali image
+    kali.vm.box = "kalilinux/rolling"
+    kali.vm.hostname = $hostname
+    kali.vm.synced_folder $local_shared_dir, "/vagrant"
+
+    # VirtualBox configuration
+    kali.vm.provider "virtualbox" do |vb|
+      # Name in VirtualBox
+      vb.name = $vm_name
+      # Disable Remote Display server ffs Kali
+      vb.customize ["modifyvm", :id, "--vrde=off"]
+    end
+
+    # Install requested apt packages
+    kali.vm.provision "Install specified apt packages #{$apt_packages} and Python dependency packages", type: "shell", privileged: true, inline: <<~APT_SCRIPT
+      apt-get update
+      apt-get --yes upgrade
+      apt-get --yes install #{$apt_packages.join(' ')} \
+                            curl git gcc make zlib1g-dev libssl-dev libffi-dev libsqlite3-dev \
+                            libbz2-dev libreadline-dev liblzma-dev
+    APT_SCRIPT
+
+    # Install and setup pyenv
+    pyenvrc_file = "/etc/profile.d/pyenvrc"
+    kali.vm.provision "Install and setup pyenv", type: "shell", privileged: $run_as_root, inline: <<~PYENV_SETUP_SCRIPT
+      set -e
+      # Install pyenv if not already there
+      if [ ! -e ~/.pyenv ]; then
+        # Split up due to noisy unnecessary stderr on both commands
+        curl --silent --output /tmp/pyenv.run https://pyenv.run
+        bash /tmp/pyenv.run 2>&1
+      else
+        echo "WARNING: ~/.pyenv exists - Skipping pyenv installation" 1>&2
+      fi
+	# The BASH Heredocs must use tabs: https://www.shellcheck.net/wiki/SC1040
+        echo "INFO: Creating #{pyenvrc_file} to be sourced in ~/.#{$preferred_shell}rc with contents:"
+	cat <<-'PYRC' | sudo tee #{pyenvrc_file}  # Deliberate no -a
+		export PYENV_ROOT="$HOME/.pyenv"
+		command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
+		eval "$(pyenv init -)"
+	PYRC
+      echo "INFO: Adding ". #{pyenvrc_file}" to ~/.#{$preferred_shell}rc and ~/.profile, only if not already there"
+      if ! grep #{pyenvrc_file} ~/.#{$preferred_shell}rc; then echo ". #{pyenvrc_file}" | tee -a ~/.#{$preferred_shell}rc; fi
+      if ! grep #{pyenvrc_file} ~/.profile; then echo ". #{pyenvrc_file}" | tee -a ~/.profile; fi
+    PYENV_SETUP_SCRIPT
+
+    # Install specified Python version using pyenv and set as global default
+    kali.vm.provision "Install Python #{$python_version}, set as global default version and install #{$pip_packages}", type: "shell", privileged: $run_as_root, inline: <<~PYENV_INSTALL_SCRIPT
+      set -e
+      . #{pyenvrc_file}
+      pyenv install --skip-existing #{$python_version} 2>&1
+      pyenv global #{$python_version}
+      pip install -U pip #{$pip_packages.join(' ')}
+    PYENV_INSTALL_SCRIPT
+
+    # Clone specified git repos, if specified
+    if $git_repos.length > 0
+      kali.vm.provision "Cloning specified git_repos to #{$git_repos_dir}", type: "shell", privileged: $run_as_root, inline: <<~GIT_REPOS_SCRIPT
+        set -e
+        clone_needs_sudo=""
+        if [ -d #{$git_repos_dir} ]; then
+          user_writable_git_dir=$( find #{$git_repos_dir} -maxdepth 0 -writable )
+          if [ "#{$git_repos_dir}" != "$user_writable_git_dir" ]; then
+            clone_needs_sudo="sudo"
+          fi
+        else
+          echo mkdir #{$git_repos_dir}
+        fi
+        cd #{$git_repos_dir}
+        for url in `echo #{$git_repos.join(' ')}`; do
+          project_dir=${url##http*/} 
+          echo "INFO: Cloning $url to #{$git_repos_dir}/$project_dir..."
+          if [ ! -d $project_dir ]; then
+            $clone_needs_sudo git clone $url
+            if (("${#clone_needs_sudo[@]}" > 0)); then sudo chown -R vagrant $project_dir; fi
+          else
+            echo "already exists - skipping" 1>&2
+          fi
+        done
+      GIT_REPOS_SCRIPT
+    end
+
+    # pipx install specified projects, if specified
+    if $pipx_projects.length > 0
+      # TODO make more efficient as bash loop
+      $pipx_projects.each do |path|
+        kali.vm.provision "pipx installing #{path}", type: "shell", privileged: $run_as_root, inline: <<~PIPX_INSTALL_SCRIPT
+          set -e
+          . #{pyenvrc_file}
+          pipx install #{path}
+        PIPX_INSTALL_SCRIPT
+      end
+      kali.vm.provision "Running pipx ensurepath", type: "shell", privileged: $run_as_root, inline: "pipx ensurepath"
+    end
+
+    # Run custom specific setup script
+    kali.vm.provision "Run custom setup script", type: "shell", privileged: $run_as_root, inline: <<~SETUP_SCRIPT
+      #{$custom_setup_script}
+      echo "INFO: Copying this script to the shared directory in case it needs to be run again, excluding this comment/cmd"
+      cat /tmp/vagrant-shell | head -n -2 | sed -e '1i#!/usr/bin/env bash' | tee /vagrant/vagrant-custom-setup.sh  # delib no -a
+    SETUP_SCRIPT
+  end
+end

--- a/kali/Vagrantfile
+++ b/kali/Vagrantfile
@@ -23,7 +23,6 @@ $python_version = "3.12"
 
 # These will be installed as root regardless of $run_as_root
 $apt_packages = [
-  "git",
   "tree",
   "vim"
 ]
@@ -142,7 +141,7 @@ Vagrant.configure("2") do |config|
             $clone_needs_sudo git clone $url
             if (("${#clone_needs_sudo}" > 0)); then sudo chown -R vagrant $project_dir; fi
           else
-            echo "already exists - skipping" 1>&2
+            echo "WARNING: $project_dir already exists - skipping" 1>&2
           fi
         done
       GIT_REPOS_SCRIPT

--- a/kali/Vagrantfile
+++ b/kali/Vagrantfile
@@ -35,9 +35,8 @@ $git_repos = [
   "https://github.com/ly4k/Certipy"
 ]
 
-# Packages to install with pip into pyenv $python_version
+# Packages to install with pip into pyenv $python_version (pipx already installed)
 $pip_packages = [
-  "pipx"
 ]
 
 # Full path to projects to install with pipx using pyenv $python_version
@@ -116,7 +115,7 @@ Vagrant.configure("2") do |config|
       . #{pyenvrc_file}
       pyenv install --skip-existing #{$python_version} 2>&1
       pyenv global #{$python_version}
-      pip install -U pip #{$pip_packages.join(' ')}
+      pip install -U pip pipx #{$pip_packages.join(' ')}
     PYENV_INSTALL_SCRIPT
 
     # Clone specified git repos, if specified


### PR DESCRIPTION
# Description

This PR:
  1. New Kali VM includes the following customization and documentation of:
    - Shared directory
    - Preferred shell
    - Hostname
    - Python
    - APT packages
    - Git repos and location
    - Pip packages
    - Pipx projects
    - Custom setup script
  2. Updated main README

Before merging ensure:
- [x] tests pass
- [x] docs are updated, list:
  -  [x] README.md
  -  [x] kali/README.md

---
# Testing
## `$run_as_root=false` 

<details>

- [x] `vagrant up` works without errors and
    - [x] VM named `vagrant-kalilinux-rolling`
    - [x] Remote Server disabled
    <details>
    
    ![image](https://github.com/hdub-tech/vagrantfiles/assets/14808878/a5b0bf71-a3cb-40de-bb6d-c30656d5e008)
    </details>

- [x] Specific things work when accessing the VM via `vagrant ssh` :    
    - [x] `custom_setup_script` executed
    - [x] hostname `kali`
    - [x] Preferred shell has `PATH` updated for `pyenv` and `pipx`
    - [x] 3.12 Python set as global pyenv default
    - [x] `apt_packages` installed 
    - [x] `git_repos` cloned to `git_repos_dir` with correct ownership
    - [x] `pipx_project` installed

    <details>
    
    ![image](https://github.com/hdub-tech/vagrantfiles/assets/14808878/cf00d66f-cea4-499b-a196-9ddf86438fba)
    </details>

- [x] `vagrant up --provision` works without errors if no changes (Idempotence) and doesn't cause env duplication
    - [x] no extras in rc files 
    - [x] `PATH` sane
    - [x] `vagrant-custom-setup.sh` not duped
    <details>
    
    ![image](https://github.com/hdub-tech/vagrantfiles/assets/14808878/461cbcb2-f3d3-4fa8-99b2-2daa9c03a5ec)
    </details>
</details>

---
## `$run_as_root=true` and custom `$git_repos_dir`

<details>

- [ ] Specific things work when accessing the VM via `vagrant ssh` :    
    - [x] `vagrant` user unmodified
    
        <details>
        
        - [x] `custom_setup_script` with `cd /vagrant` doesn't effect unprivileged user
        - [x] Preferred shell still default (zsh)
        - [x] `PATH` not updated for `pyenv` and `pipx`
        - [x] System installed Python not pyenv installed Python
        - [x] `apt_packages` installed 
        - [x] `git_repos` cloned to `git_repos_dir` which is inaccessible to unprivileged user
        - [x] `pipx_project` not accessible to unprivileged user

        ![image](https://github.com/hdub-tech/vagrantfiles/assets/14808878/3851de2a-787f-4032-a608-3674ca84e441)
        </details>
        
    - [x] `root` was updated
    
        <details>
        
        - [x] `custom_setup_script` with `cd /vagrant` on login
        - [x] Preferred shell has `PATH` updated for `pyenv` and `pipx`
        - [x] 3.12 Python set as global pyenv default
        - [x] `apt_packages` installed 
        - [x] `git_repos` cloned to `git_repos_dir` with correct ownership
        - [x] `pipx_project` installed

        ![image](https://github.com/hdub-tech/vagrantfiles/assets/14808878/4e288138-5a79-4a5d-9dd2-6778ed14ca54)         
        </details>
</details>