### PR TITLE
Kali bugfixes: git-delta and binaryninja sha

### DIFF
--- a/kali/defaults.yml
+++ b/kali/defaults.yml
@@ -61,7 +61,7 @@ pipx_projects:
 apps_dir: /opt
 # ...and the urls to use for it
 compressed_app_urls:
-  - { url: 'https://cdn.binary.ninja/installers/binaryninja_free_linux.zip', algorithm: sha256, checksum: 92789c0bd3e1f75b1a03d80e74eb7ea8d3a95e19f7915557774a0ad402674926 }  # https://binary.ninja/js/hashes.js
+  - { url: 'https://cdn.binary.ninja/installers/binaryninja_free_linux.zip', algorithm: sha256, checksum: 60aaf7a05d149bb0fbca82d7fce162c6e4170d9e926e90e61162156c23f1c252 }  # https://binary.ninja/js/hashes.js
   - { url: 'https://download.jetbrains.com/idea/idea-2026.1.1.tar.gz', algorithm: sha256, checksum: 7a58d386f2a2e5a8cd7e4591657b4fe599aeac22d960c7accf5f927846507bfb }
   - { url: 'https://web9001.nomachine.com/download/9.5/Linux/nomachine_9.5.7_2_amd64.deb',  algorithm: md5, checksum: 0bfa0b79d4340d864384305eb99e39b8 }
   - { url: 'https://github.com/dandavison/delta/releases/download/0.19.2/git-delta_0.19.2_amd64.deb', algorithm: sha256, checksum: ea4f0222950ee750a3d38dd80d03bce4cee07a3f63928fc47548383bcaf23093 }

--- a/kali/defaults.yml
+++ b/kali/defaults.yml
@@ -26,7 +26,6 @@ apt_packages:
   - bytecode-viewer
   - ghidra
   - ghidra-dbgsym
-  - git-delta
   - jq
   - meld
   - podman
@@ -65,6 +64,7 @@ compressed_app_urls:
   - { url: 'https://cdn.binary.ninja/installers/binaryninja_free_linux.zip', algorithm: sha256, checksum: 92789c0bd3e1f75b1a03d80e74eb7ea8d3a95e19f7915557774a0ad402674926 }  # https://binary.ninja/js/hashes.js
   - { url: 'https://download.jetbrains.com/idea/idea-2026.1.1.tar.gz', algorithm: sha256, checksum: 7a58d386f2a2e5a8cd7e4591657b4fe599aeac22d960c7accf5f927846507bfb }
   - { url: 'https://web9001.nomachine.com/download/9.5/Linux/nomachine_9.5.7_2_amd64.deb',  algorithm: md5, checksum: 0bfa0b79d4340d864384305eb99e39b8 }
+  - { url: 'https://github.com/dandavison/delta/releases/download/0.19.2/git-delta_0.19.2_amd64.deb', algorithm: sha256, checksum: ea4f0222950ee750a3d38dd80d03bce4cee07a3f63928fc47548383bcaf23093 }
 
 # Projects to install with curl | bash light help me
 curl_bash_projects:

--- a/kali/overrides.yml.test
+++ b/kali/overrides.yml.test
@@ -25,7 +25,6 @@ apt_packages:
   - bytecode-viewer
   #- ghidra
   #- ghidra-dbgsym
-  #- git-delta
   - jq
   #- meld
   #- podman
@@ -64,6 +63,7 @@ compressed_app_urls:
   - { url: 'https://cdn.binary.ninja/installers/binaryninja_free_linux.zip', algorithm: sha256, checksum: 92789c0bd3e1f75b1a03d80e74eb7ea8d3a95e19f7915557774a0ad402674926 }  # https://binary.ninja/js/hashes.js
   #- { url: 'https://download.jetbrains.com/idea/idea-2026.1.1.tar.gz', algorithm: sha256, checksum: 7a58d386f2a2e5a8cd7e4591657b4fe599aeac22d960c7accf5f927846507bfb }
   - { url: 'https://web9001.nomachine.com/download/9.5/Linux/nomachine_9.5.7_2_amd64.deb',  algorithm: md5, checksum: 0bfa0b79d4340d864384305eb99e39b8 }
+  - { url: 'https://github.com/dandavison/delta/releases/download/0.19.2/git-delta_0.19.2_amd64.deb', algorithm: sha256, checksum: ea4f0222950ee750a3d38dd80d03bce4cee07a3f63928fc47548383bcaf23093 }
 
 # Projects to install with curl | bash light help me
 curl_bash_projects:


### PR DESCRIPTION
# Description

This PR:
  1. Fixes updated BinaryNinja sha256 sum for Kali VM
  <img width="1911" height="228" alt="Screenshot from 2026-08-05 16-33-03" src="https://github.com/user-attachments/assets/48964823-118f-48aa-95ab-4a67e04cf8e3" />

  2. Fixes git-delta no longer being an apt package for Kali VM
  <img width="745" height="123" alt="Screenshot from 2026-08-05 16-33-25" src="https://github.com/user-attachments/assets/bbf6f745-abea-4d7a-a154-6a62a3a77648" />


Before merging ensure:
- [x] validate job is passing: N/A
- [x] docs are updated:  N/A

---
# Testing

- [x] `vagrant up` works without errors with DEFAULTS
    <details>
    
    - [x] Download + extract + checksum projects
       <details>
       
       <img width="1917" height="227" alt="Screenshot from 2026-08-05 16-34-06" src="https://github.com/user-attachments/assets/8fb3e291-b9cf-4da3-be6b-84bedf606f84" />
       
       <img width="1920" height="341" alt="Screenshot from 2026-08-05 16-34-23" src="https://github.com/user-attachments/assets/7b494c17-5947-4cdc-9218-2c5395d8a355" />

       </details>
    
    </details>

- [x] `vagrant up --provision` (Idempotence) works without errors with DEFAULTS
    <details>
    
    - [x] Download + extract + checksum projects
       <details>
       
       <img width="1920" height="276" alt="Screenshot from 2026-08-05 16-35-41" src="https://github.com/user-attachments/assets/2a251df2-3809-445e-b96a-f3914a68497b" />

       </details>

- [x] Specific things work when accessing the VM via `vagrant ssh`
    - [x] delta installed on CLI
    <details>
    
    <img width="334" height="77" alt="image" src="https://github.com/user-attachments/assets/c19d2a7b-4137-4158-8222-86dd3d518363" />
    </details>

- [x] Specific things work when accessing the VM via the desktop environment
    - [x] BinaryNinja still launches from shortcut
    <details>
    
    <img width="1285" height="613" alt="image" src="https://github.com/user-attachments/assets/84dcfd6f-166e-4cc8-94c8-4bd14421047d" />
    </details>
